### PR TITLE
Add reading time to blog teasers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,7 +14,8 @@ module.exports = {
         design: {
           name: 'living-stories',
           version: '0.0.2'
-        }
+        },
+        resolveReadingTime: true
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11069,6 +11069,12 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "reading-time": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.2.0.tgz",
+      "integrity": "sha512-5b4XmKK4MEss63y0Lw0vn0Zn6G5kiHP88mUnD8UeEsyORj3sh1ghTH0/u6m1Ax9G2F4wUZrknlp6WlIsCvoXVA==",
+      "dev": true
+    },
     "recursive-readdir": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "react-helmet": "5.2.1"
   },
   "devDependencies": {
-    "tls": "0.0.1",
-    "net": "1.0.2",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "4.3.0",
@@ -33,9 +31,12 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-prettier": "3.1.0",
     "eslint-plugin-react": "7.13.0",
+    "lodash": "^4.17.11",
+    "net": "1.0.2",
     "node-sass": "^4.12.0",
     "prettier": "1.17.1",
-    "lodash": "^4.17.11"
+    "reading-time": "^1.2.0",
+    "tls": "0.0.1"
   },
   "release": {
     "extends": "@livingdocs/semantic-release-presets/github"

--- a/plugins/gatsby-source-livingdocs/gatsby-node.js
+++ b/plugins/gatsby-source-livingdocs/gatsby-node.js
@@ -8,11 +8,13 @@ const {documentTypes, defaultDocumentType} = require('./includes/config/document
 const includesConfig = require('./includes/config')
 const renderLayout = require('./includes/render')
 const resolveIncludes = require('./includes')
+const readingTime = require('reading-time')
 
 exports.sourceNodes = async ({actions}, configOptions) => {
   if (!configOptions.design) return console.warn('config.options.design missing')
   if (!configOptions.design.name) { return console.warn("config.options.design.name missing example: 'living-times'") }
   if (!configOptions.design.version) { return console.warn("config.options.design.version missing example: '0.0.1'") }
+  const resolveReadingTime = _.get(configOptions, 'resolveReadingTime', true)
 
   const {createNode} = actions
 
@@ -94,6 +96,7 @@ exports.sourceNodes = async ({actions}, configOptions) => {
 
   // Create your node object
   const processPublication = async (publication, design) => {
+    console.log(resolveReadingTime)
     const html = await getPublication(publication, design)
     const nodeData = {
       id: `${publication.systemdata.documentId}`,
@@ -109,7 +112,8 @@ exports.sourceNodes = async ({actions}, configOptions) => {
       publication,
       extra: {
         slug: slugify(publication.metadata.title, publication.systemdata.documentId),
-        html
+        html,
+        stats: resolveReadingTime ? readingTime(html) : null
       }
     }
     return nodeData

--- a/src/components/teaserCard/index.js
+++ b/src/components/teaserCard/index.js
@@ -3,7 +3,7 @@ import {Link} from 'gatsby'
 import {resolveAuthorName} from '../helpers/resolveAuthorName'
 
 const BlogTeaser = props => {
-  const {title, publishDate, teaserImage, description, authors, slug, flag} = props
+  const {title, publishDate, teaserImage, description, authors, slug, flag, readingTime} = props
   const url = teaserImage && teaserImage.originalUrl
   const date = new Date(publishDate).toLocaleDateString('de-DE')
   return (
@@ -19,7 +19,7 @@ const BlogTeaser = props => {
           <ul className="teaser-card__byline">
             {authors &&
               authors.references.map(author => resolveAuthorName(author.id))}
-            <li>{date}</li>
+            <li>{date} - {readingTime}</li>
           </ul>
         </div>
       </div>

--- a/src/components/teaserFeatureCard/index.js
+++ b/src/components/teaserFeatureCard/index.js
@@ -3,7 +3,7 @@ import {Link} from 'gatsby'
 import {resolveAuthorName} from '../helpers/resolveAuthorName'
 
 const teaserFeatureCard = props => {
-  const {title, publishDate, teaserImage, description, authors, flag, slug} = props
+  const {title, publishDate, teaserImage, description, authors, flag, slug, readingTime} = props
   const url = teaserImage && teaserImage.originalUrl
   const isSmall = props.small ? 'teaser-feature-card--small' : ''
   const date = new Date(publishDate).toLocaleDateString('de-DE')
@@ -24,7 +24,7 @@ const teaserFeatureCard = props => {
           <ul className="teaser-feature-card__byline">
             {authors &&
               authors.references.map(author => resolveAuthorName(author.id))}
-            <li>{date}</li>
+            <li>{date} - {readingTime}</li>
           </ul>
         </div>
       </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -27,6 +27,7 @@ class Homepage extends React.Component {
               small={false}
               {...intialPostData.node.publication.metadata}
               slug={intialPostData.node.extra.slug}
+              readingTime={intialPostData.node.extra.stats.text}
               key={intialPostData.node.publication.systemdata.documentId}
             />
           </div>
@@ -38,6 +39,7 @@ class Homepage extends React.Component {
                   small={true}
                   {...data.node.publication.metadata}
                   slug={data.node.extra.slug}
+                  readingTime={data.node.extra.stats.text}
                   key={data.node.publication.systemdata.documentId}
                 />
               )
@@ -53,6 +55,7 @@ class Homepage extends React.Component {
                   <TeaserCard
                     {...data.node.publication.metadata}
                     slug={data.node.extra.slug}
+                    readingTime={data.node.extra.stats.text}
                     key={data.node.publication.systemdata.documentId}
                   />
                 )
@@ -73,6 +76,9 @@ export const query = graphql`
         node {
           extra {
             slug
+            stats {
+              text
+            }
           }
           publication {
             metadata {


### PR DESCRIPTION
### Relations:
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/2330

### Description
Resolves reading time within the `gatsby-plugin-livingdocs` from the HTML.