### PR TITLE
fix: use correct teaserImage for sharing blogposts

### DIFF
--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -8,14 +8,14 @@ import Twitter from './twitter'
 const warnPropMissing = prop => console.warn(`SEO: missing ${prop} for applying correct SEO information`)
 
 const seo = props => {
-  const {title, description, url, scripts} = props
+  const {title, description, url, scripts, imageUrl} = props
   if (!title) warnPropMissing('title')
   if (!description) warnPropMissing('description')
   if (!url) warnPropMissing('url')
   return (
     <>
       <Basic title={title} description={description} scripts={scripts}/>
-      <OpenGraph title={title} description={description} url={url} />
+      <OpenGraph title={title} description={description} url={url} imageUrl={imageUrl} />
       <Twitter />
     </>
   )

--- a/src/components/SEO/openGraph.js
+++ b/src/components/SEO/openGraph.js
@@ -10,7 +10,7 @@ const openGraph = props => (
     <meta property="og:description" content={props.description} />
     <meta
       property="og:image"
-      content="http://livingdocs-assets.s3.amazonaws.com/ld_logo_final@2x.png"
+      content={props.imageUrl}
     />
   </Helmet>
 )

--- a/src/templates/blogPost.js
+++ b/src/templates/blogPost.js
@@ -10,6 +10,7 @@ const blogPost = props => {
   const description = props.data.publications.publication.metadata.description
   const scripts = props.data.publications.publication.metadata.dependencies.js
   const title = props.data.publications.publication.metadata.title
+  const imageUrl = props.data.publications.publication.metadata.teaserImage.url
   const url = metadata.url
 
   // HTML - rendering the html-body
@@ -17,9 +18,15 @@ const blogPost = props => {
 
   return (
     <>
-    <ProgressBar/>
+      <ProgressBar />
       <Layout>
-        <SEO title={title} description={description} url={url} scripts={scripts}/>
+        <SEO
+          title={title}
+          description={description}
+          url={url}
+          scripts={scripts}
+          imageUrl={imageUrl}
+        />
         <div dangerouslySetInnerHTML={{__html: html}} />
       </Layout>
     </>
@@ -28,11 +35,14 @@ const blogPost = props => {
 
 export const query = graphql`
   query($slug: String!) {
-    publications(extra: {slug: {eq: $slug}}) {
+    publications(extra: { slug: { eq: $slug } }) {
       publication {
         metadata {
           title
           description
+          teaserImage {
+            url
+          }
           dependencies {
             js {
               code

--- a/src/templates/pages.js
+++ b/src/templates/pages.js
@@ -6,6 +6,7 @@ import {metadata} from '../../config'
 
 const page = props => {
   // SEO - description | title | url
+  const imageUrl = props.data.publications.publication.metadata.teaserImage.url
   const description = props.data.publications.publication.metadata.description
   const title = props.data.publications.publication.metadata.title
   const url = metadata.url
@@ -14,7 +15,7 @@ const page = props => {
   const html = props.data.publications.extra.html
   return (
     <Layout>
-      <SEO title={title} description={description} url={url}/>
+      <SEO title={title} description={description} url={url} imageUrl={imageUrl}/>
       <div dangerouslySetInnerHTML={{__html: html}} />
     </Layout>
   )


### PR DESCRIPTION
When you share a blog post over social media, the preview shows no image.

## Changelog
- Correctly show a teaser image when sharing a blogpost on social media