### PR TITLE
fix(header): link back to main page for the logo

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -10,7 +10,9 @@ const Header = () => (
             <a className="meta-bar__logo logo" href="https://livingdocs.io">
               <img src={logo} alt="Living Stories" />
             </a>
-            <b className="meta-bar__title"><a href="/" style={{textDecoration: 'none'}}>Livingdocs Blog</a></b>
+            <b className="meta-bar__title">
+              <a href="/" style={{textDecoration: 'none'}}>Livingdocs Blog</a>
+            </b>
           </div>
           <div className="meta-bar__unit">
             <nav className="meta-nav">


### PR DESCRIPTION
### Description
Our logo always links back to livingdocs.io, let's keep that consistent

### Changelog
- Header: logo links to `https://livingdocs.io`
- Header: `livingdocs blog` now links to the base path of the blog